### PR TITLE
Check if we can get dialog title to see if we can access resources

### DIFF
--- a/src/android/FingerprintAuthAux.java
+++ b/src/android/FingerprintAuthAux.java
@@ -498,6 +498,15 @@ public class FingerprintAuthAux {
                 mFragment.setArguments(bundle);
                 mFragment.setmFingerPrintAuth(auth);
 
+                // If we can't access the resources needed to show the fragment, don't open it
+                Boolean canAccessResources = verifyResourcesAccess(cordova);
+
+                if(!canAccessResources) {
+                    mPluginResult = new PluginResult(PluginResult.Status.ERROR, "Failed to open fingerprint dialog");
+                    mCallbackContext.sendPluginResult(mPluginResult);
+                    return;
+                }
+
                 if (initCipher(mode, cordova)) {
                     mFragment.setCancelable(false);
                     // Show the fingerprint dialog. The user has the option to use the fingerprint with
@@ -515,6 +524,16 @@ public class FingerprintAuthAux {
                 }
             }
         });
+    }
+
+    // verify if we can access resources needed to show the dialogfragment
+    private Boolean verifyResourcesAccess(CordovaInterface cordova) {
+        int fingerprint_auth_dialog_title_id = cordova.getActivity().getResources().getIdentifier("fingerprint_auth_dialog_title", "string", packageName);
+        // 0 means that the resource identifier was not found
+        if(fingerprint_auth_dialog_title_id == 0) {
+           return false;
+        }
+        return true;
     }
 
     public void onAuthenticated(boolean withFingerprint) {


### PR DESCRIPTION
We have Resources$NotFoundExceptions in our app.

https://play.google.com/apps/publish/?account=6484040236532654864#AndroidMetricsErrorsPlace:p=com.officient.app&appid=4976113493936699113&appVersion=PRODUCTION&lastReportedRange=LAST_60_DAYS&showHidden=true&clusterName=apps/com.officient.app/clusters/f58261eb&detailsAppVersion=PRODUCTION

For some reason the resources are not available in some cases. To try and handle this, added a check that tries to get a resource (dialog title) as a test before opening the fingerprint dialog. If we can't find the resource, don't open the dialog (because it would crash) and show pin code login instead.
